### PR TITLE
fix: allow eslint_flags to contain flags rather than just patterns

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,11 +12,11 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  $(npm bin)/eslint -f="json" "${INPUT_ESLINT_FLAGS:-'.'}" \
+  $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} \
     | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
     | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else
   # github-pr-check,github-check (GitHub Check API) doesn't support markdown annotation.
-  $(npm bin)/eslint -f="stylish" "${INPUT_ESLINT_FLAGS:-'.'}" \
+  $(npm bin)/eslint -f="stylish" ${INPUT_ESLINT_FLAGS:-'.'} \
     | reviewdog -f="eslint" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
 fi


### PR DESCRIPTION
I just discovered this action and it is amazing! Thanks!

I found out a tiny bug in it that is preventing me from specifying some other eslint options.

**Problem**

The way the `eslint_flags` config is working right now doesn't allow to specify eslint flags, but just file patterns, not allowing to specify things such as the extension of the files (`--ext .ts`).

With the current version, when I specify more flags than just patterns, eslint interprets them as patterns too:

```
> No files matching the pattern "./src ./test ./types --ext .ts --ext .tsx" were found.
```

For the extension, It is true that it could also be specified as a pattern (`'src/**/*.ts'`)

**Solution**

Remove the quotes around the `${INPUT_ESLINT_FLAGS:-'.'}` statement in the `entrypoint.sh` file.

