### PR TITLE
Bypassing parse error in jq because of eslint warnings before lint results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-.vscode/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,8 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  npm run lint \
-    | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
-    | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
+    $(npm bin)/eslint -f checkstyle ${INPUT_ESLINT_FLAGS:-'.'} \
+    | reviewdog -f=checkstyle -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else
   # github-pr-check,github-check (GitHub Check API) doesn't support markdown annotation.
   $(npm bin)/eslint -f="stylish" ${INPUT_ESLINT_FLAGS:-'.'} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  $(npm bin)/eslint -f="json" --ext .vue,.js,.ts . | tail -n 1 \
+  $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} | tail -n 1 \
     | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
     | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} \
+  npm run lint \
     | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
     | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  npm run lint \
+  $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} \
     | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
     | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
     | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else
   # github-pr-check,github-check (GitHub Check API) doesn't support markdown annotation.
-  $(npm bin)/eslint -f="stylish" ${INPUT_ESLINT_FLAGS:-'.'} \
-    | reviewdog -f="eslint" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
+  $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} | tail -n 1 \
+    | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
+    | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter="${INPUT_REPORTER:-github-pr-check}" -level="${INPUT_LEVEL}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,9 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-    $(npm bin)/eslint -f checkstyle ${INPUT_ESLINT_FLAGS:-'.'} \
-    | reviewdog -f=checkstyle -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
+  npm run lint \
+    | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
+    | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else
   # github-pr-check,github-check (GitHub Check API) doesn't support markdown annotation.
   $(npm bin)/eslint -f="stylish" ${INPUT_ESLINT_FLAGS:-'.'} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ $(npm bin)/eslint --version
 
 if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   # Use jq and github-pr-review reporter to format result to include link to rule page.
-  $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} \
+  $(npm bin)/eslint -f="json" --ext .vue,.js,.ts . | tail -n 1 \
     | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
     | reviewdog -efm="%f:%l:%c:%m" -name="eslint" -reporter=github-pr-review -level="${INPUT_LEVEL}"
 else


### PR DESCRIPTION
Hey developers sitting at reviewdog, thank you so much for this amazing tool, it works like charm!!

In my case, eslint logs 

![image](https://user-images.githubusercontent.com/45892659/79628066-f57fc100-813d-11ea-8cc7-ea126294aab8.png)

and because of logging 

```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0

YOUR TYPESCRIPT VERSION: 3.8.3

Please only submit bug reports when using the officially supported version.
=============

``` 
before logging warnings or errors in actual code and `jq` logs a parse error

![image](https://user-images.githubusercontent.com/45892659/79628091-3677d580-813e-11ea-8987-6fcc82ef030d.png)

the output of `$(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'}` in my case looks like 
```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0

YOUR TYPESCRIPT VERSION: 3.8.3

Please only submit bug reports when using the officially supported version.

=============
[{"filePath":"~babel.config.js","messages":[],"errorCount":0,"warningCount":0,"fixableErrorCount":0,"fixableWarningCount":0}] and so on

```


so this proposal takes only the eslint log from **last line** of STDOUT from `$(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'}` and therefore stops `jq` from generating parsing errors like above..

Please let me know if there're any edits that are required to fit this PR into life of reviewdog!!