### PR TITLE
feat(action-options): add tool_name option for reviewdog reporter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   workdir:
     description: "The directory from which to look for and run eslint. Default '.'"
     default: '.'
+  tool_name:
+    description: 'Tool name to use for reviewdog reporter'
+    default: 'eslint'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ if [ "${INPUT_REPORTER}" == 'github-pr-review' ]; then
   $(npm bin)/eslint -f="json" ${INPUT_ESLINT_FLAGS:-'.'} \
     | jq -r '.[] | {filePath: .filePath, messages: .messages[]} | "\(.filePath):\(.messages.line):\(.messages.column):\(.messages.message) [\(.messages.ruleId)](https://eslint.org/docs/rules/\(.messages.ruleId))"' \
     | reviewdog -efm="%f:%l:%c:%m" \
-        -name="eslint" \
+        -name="${INPUT_TOOL_NAME}" \
         -reporter=github-pr-review \
         -filter-mode="${INPUT_FILTER_MODE}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
@@ -27,6 +27,7 @@ else
   # github-pr-check,github-check (GitHub Check API) doesn't support markdown annotation.
   $(npm bin)/eslint -f="stylish" ${INPUT_ESLINT_FLAGS:-'.'} \
     | reviewdog -f="eslint" \
+        -name="${INPUT_TOOL_NAME}" \
         -reporter="${INPUT_REPORTER:-github-pr-check}" \
         -filter-mode="${INPUT_FILTER_MODE}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \


### PR DESCRIPTION
Hey reviewdog team! thanks for this awesome action! 

I implemented it on a private project to take care of the javascript guidelines and I notice a use case that it's not supported at the time, as it is a little wired for small projects, but not that uncommon. The project is a rails 4.2 app with `Angular` and its transitioning from `ES5` on the assets pipeline to `ES6` with `webpacker`. As a result there are 2 javascripts directories, `app/assets/javascript` for old files or non-migrated files and  `app/javascript`for the ES6-webpacker part of the project. For this reason, i had to had two steps on my `reviewdog` check for `eslint`:

```
name: reviewdog
on: [pull_request]
jobs:
  eslint:
    name: eslint(ES5)
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v1
      - name: eslint(ES5)
        uses: reviewdog/action-eslint@v1
        with:
          github_token: ${{ secrets.github_token }}
          reporter: github-pr-check
          workdir: 'app/assets/javascripts'
      - name: eslint(ES6)
        uses: review/action-eslint@master
        with:
          github_token: ${{ secrets.github_token }}
          reporter: github-pr-check
          workdir: 'app/javascript'
```

the problem is that as the action uses "eslint" as de name of the reporter for both checks, the first report is ignored and only the second one is used.

I managed to solve this by adding the `tool_name` option when the action executes `reviewdog` (I stole the idea from your `reviewdog/action-rubocop` repo)

Hope this PR is well recieved and become useful for someone else!