### PR TITLE
Provide a default Github token

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,32 +9,27 @@ jobs:
       - name: eslint-github-pr-check
         uses: ./
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           eslint_flags: 'testdata/ --ignore-pattern /test-subproject/'
       - name: eslint-github-check
         uses: ./
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-check
           level: warning
           eslint_flags: 'testdata/ --ignore-pattern /test-subproject/'
       - name: eslint-github-pr-review
         uses: ./
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           eslint_flags: 'testdata/ --ignore-pattern /test-subproject/'
       - name: eslint-subproject-github-pr-review
         uses: ./
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           workdir: ./test-subproject
           eslint_flags: 'sub-testdata/'
       - name: eslint-subproject
         uses: ./
         with:
-          github_token: ${{ secrets.github_token }}
           workdir: ./test-subproject
           eslint_flags: 'sub-testdata/'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ code review experience.
 
 ### `github_token`
 
-**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.
+**Required**. Default is `${{ github.token }}`.
 
 ### `level`
 
@@ -81,7 +81,6 @@ jobs:
       - name: eslint
         uses: reviewdog/action-eslint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Change reporter.
           eslint_flags: 'src/'
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
     required: true
+    default: ${{ github.token }}
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'


### PR DESCRIPTION
[See similar PR for other reviewdog action here.](https://github.com/reviewdog/action-golangci-lint/pull/38)

This makes it so that users of this action no longer need to pass `github_token: ${{ secrets.github_token }}`, we just provide it by default. They can still pass it if they like.
Makes the workflow file less noisy.