### PR TITLE
Add legacy-peer-deps option for peer dependencies conflicts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ ESLINT_FORMATTER='/formatter.js'
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 if [ ! -f "$(npm bin)/eslint" ]; then
-  npm install
+  npm install --legacy-peer-deps
 fi
 
 $(npm bin)/eslint --version


### PR DESCRIPTION
#49 

This can help with peer dependencies conflicts, missing package-lock.json in repository and use yarn.