### PR TITLE
Ea update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine
+FROM node:14.15.4-alpine3.12
 
 ENV REVIEWDOG_VERSION=v0.11.0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ ESLINT_FORMATTER='/formatter.js'
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 if [ ! -f "$(npm bin)/eslint" ]; then
-  npm install --legacy-peer-deps
+  npm install --only=dev
 fi
 
 $(npm bin)/eslint --version

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ ESLINT_FORMATTER='/formatter.js'
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 if [ ! -f "$(npm bin)/eslint" ]; then
-  npm install --only=dev
+  npm install --only=dev --ignore-scripts
 fi
 
 $(npm bin)/eslint --version


### PR DESCRIPTION
The Dockerfile is currently locked pointing at node:current-latest, which recently updated to using node version 15.0.8 (we use 14.x so this broke us). This updates the Dockerfile to point at a node image that uses node version 14.x