### PR TITLE
Add an option to use yarn as package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Optional. Flags and args of eslint command. Default: '.'
 
 Optional. The directory from which to look for and run eslint. Default '.'
 
+### `package_manager`
+
+Optional. Package manager for installing node modules [npm,yarn]. Default: 'npm'
+
 ## Example usage
 
 You also need to install [eslint](https://github.com/eslint/eslint).

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'eslint'
+  package_manager:
+    description: "Package manager for installing node modules [npm,yarn]. Default: 'npm'"
+    default: 'npm'
 runs:
   using: 'composite'
   steps:
@@ -55,6 +58,7 @@ runs:
         INPUT_ESLINT_FLAGS: ${{ inputs.eslint_flags }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
+        INPUT_PACKAGE_MANAGER: ${{ inputs.package_manager }}
 branding:
   icon: 'alert-octagon'
   color: 'blue'

--- a/script.sh
+++ b/script.sh
@@ -11,9 +11,14 @@ echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/review
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
-if [ ! -f "$(npm bin)/eslint" ]; then
-  echo '::group:: Running `npm install` to install eslint ...'
-  npm install
+PACKAGE_MANAGER="${INPUT_PACKAGE_MANAGER}"
+if [ $PACKAGE_MANAGER != "npm" -a $PACKAGE_MANAGER != "yarn" ]; then
+  echo "Unsupported package manager. Specify npm or yarn"
+  exit 1
+fi
+if [ ! -f "$($PACKAGE_MANAGER bin)/eslint" ]; then
+  echo "::group:: Running `$PACKAGE_MANAGER install` to install eslint ..."
+  $PACKAGE_MANAGER install
   echo '::endgroup::'
 fi
 


### PR DESCRIPTION
This PR adds an option to use yarn as a package manager.

# Issue
We use yarn as a package manager in our internal repository and thus we specify package versions with `yarn.lock`.
As `npm install` ignores `yarn.lock`, unexpected packages are installed and eslint fails.

# Reason
`npm intall` runs to install eslint after https://github.com/reviewdog/action-eslint/pull/72 was merged.

# Solution
I add an option to use yarn as a package manager.
This resolved our problem.
