### PR TITLE
Gracefully handle UTF8 length check errors

### DIFF
--- a/eslint-formatter-rdjson/index.js
+++ b/eslint-formatter-rdjson/index.js
@@ -28,7 +28,13 @@ function positionFromUTF16CodeUnitOffset(offset, text) {
       const lineText = line.slice(0, offset-lengthSoFar);
       // +1 because eslint offset is a bit weird and will append text right
       // after the offset.
-      column = utf8length(lineText) + 1;
+
+      try {
+        column = utf8length(lineText) + 1;
+      } catch (error) {
+        console.error('Failed to get UTF 8 length:', lineText);
+      }
+      
       break;
     }
     lengthSoFar += line.length + 1; // +1 for line-break.

--- a/eslint-formatter-rdjson/index.js
+++ b/eslint-formatter-rdjson/index.js
@@ -47,7 +47,12 @@ function positionFromLineAndUTF16CodeUnitOffsetColumn(line, column, sourceLines)
   let col = 0;
   if (sourceLines.length >= line) {
     const lineText = sourceLines[line-1].slice(0, column);
-    col = utf8length(lineText);
+
+    try {
+      col = utf8length(lineText);
+    } catch (error) {
+      console.error('Failed to get UTF 8 length:', lineText);
+    }
   }
   return {line: line, column: col};
 }


### PR DESCRIPTION
This PR adds a `try/catch` block around the UTF8 length checks in case there are errors.