### PR TITLE
fix broken surrogate pairs

### DIFF
--- a/eslint-formatter-rdjson/index.js
+++ b/eslint-formatter-rdjson/index.js
@@ -92,11 +92,9 @@ function positionFromUTF16CodeUnitOffset(offset, text) {
 function positionFromLineAndUTF16CodeUnitOffsetColumn(line, column, sourceLines) {
   let col = 0;
   if (sourceLines.length >= line) {
-    // the column is 1-origin index, but String.prototype.slice() expects 0-origin index.
-    // so we call slice(0, column-1).
+    // 1. Extract the line text until the column (exclusive)
     const lineText = sourceLines[line-1].slice(0, column-1);
-
-    // +1 because utf8length returns 0-origin index, whether we want 1-origin index.
+    // 2&3. Count length of the extracted line text in UTF-8 and +1.
     col = utf8length(lineText) + 1;
   }
   return {line: line, column: col};

--- a/eslint-formatter-rdjson/index.js
+++ b/eslint-formatter-rdjson/index.js
@@ -64,6 +64,31 @@ function positionFromUTF16CodeUnitOffset(offset, text) {
   return {line: lnum, column: column};
 }
 
+// How to get UTF-8 column from UTF-16 code unit column.
+// 1. Extract the line text until the column (exclusive).
+//    This is important when the character at the column is surrogate pair.
+// 2. Count length of the extracted line text in UTF-8.
+// 3. +1 to the length to get the UTF-8 column.
+//
+// Example:
+// - sourceLines: ["haya🐶🐱busa"]
+// - line: 1
+// - column: 7
+// - Expected output: {line: 1, column: 9}
+//
+// Ref:
+// - UTF-16 length("🐶"): 2
+// - UTF-8  length("🐶"): 4
+//                               v------- INPUT: {line: 1, column: 7}
+//                         haya🐶🐱busa
+// UTF-16 Column  (input): 12345 7 9012
+// UTF-8  Column (output): 12345 9 3456
+//                         ~~~~~~ <= utf8length("haya🐶") = 8
+//
+// The given position points to "🐱" (line:1, column: 7)
+// 1. Extract the line text until the column (exclusive): "haya🐶"
+// 2. Count length of the extracted line text in UTF-8: utf8length("haya🐶") = 8
+// 3. +1 to the length to get the UTF-8 column: 9
 function positionFromLineAndUTF16CodeUnitOffsetColumn(line, column, sourceLines) {
   let col = 0;
   if (sourceLines.length >= line) {

--- a/eslint-formatter-rdjson/testdata/result.ok
+++ b/eslint-formatter-rdjson/testdata/result.ok
@@ -5,6 +5,24 @@
   },
   "diagnostics": [
     {
+      "message": "Parsing error: Unexpected character '🐶'",
+      "location": {
+        "path": "testdata/error.js",
+        "range": {
+          "start": {
+            "line": 1,
+            "column": 1
+          }
+        }
+      },
+      "severity": "ERROR",
+      "code": {
+        "value": null,
+        "url": ""
+      },
+      "original_output": "{\"ruleId\":null,\"fatal\":true,\"severity\":2,\"message\":\"Parsing error: Unexpected character '🐶'\",\"line\":1,\"column\":1}"
+    },
+    {
       "message": "'test' is defined but never used.",
       "location": {
         "path": "testdata/test.js",
@@ -74,7 +92,7 @@
           },
           "end": {
             "line": 6,
-            "column": 3
+            "column": 4
           }
         }
       },
@@ -295,7 +313,7 @@
           },
           "end": {
             "line": 4,
-            "column": 25
+            "column": 26
           }
         }
       },
@@ -332,7 +350,7 @@
           },
           "end": {
             "line": 5,
-            "column": 19
+            "column": 20
           }
         }
       },
@@ -428,7 +446,7 @@
           },
           "end": {
             "line": 13,
-            "column": 3
+            "column": 4
           }
         }
       },
@@ -524,7 +542,7 @@
           },
           "end": {
             "line": 12,
-            "column": 5
+            "column": 6
           }
         }
       },
@@ -546,7 +564,7 @@
           },
           "end": {
             "line": 14,
-            "column": 2
+            "column": 3
           }
         }
       },
@@ -642,7 +660,7 @@
           },
           "end": {
             "line": 17,
-            "column": 1
+            "column": 2
           }
         }
       },
@@ -679,7 +697,7 @@
           },
           "end": {
             "line": 18,
-            "column": 22
+            "column": 23
           }
         }
       },

--- a/testdata/error.js
+++ b/testdata/error.js
@@ -1,0 +1,1 @@
+🐶 // test for unexpected character


### PR DESCRIPTION
the column is 1-origin index, but `String.prototype.slice()` expects 0-origin index.
so we should call `slice(0, column-1)`.

fixes #81