### PR TITLE
support npm v9

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -11,16 +11,17 @@ echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/review
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
-if [ ! -f "$(npm bin)/eslint" ]; then
+npx --offline eslint --version
+if [ $? -ne 0 ]; then
   echo '::group:: Running `npm install` to install eslint ...'
   npm install
   echo '::endgroup::'
 fi
 
-echo "eslint version:$($(npm bin)/eslint --version)"
+echo "eslint version:$(npx --offline eslint --version)"
 
 echo '::group:: Running eslint with reviewdog 🐶 ...'
-$(npm bin)/eslint -f="${ESLINT_FORMATTER}" ${INPUT_ESLINT_FLAGS:-'.'} \
+npx --offline eslint -f="${ESLINT_FORMATTER}" ${INPUT_ESLINT_FLAGS:-'.'} \
   | reviewdog -f=rdjson \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-review}" \


### PR DESCRIPTION
fix: #152 

According to [the document](https://docs.npmjs.com/cli/v8/commands/npm-exec#offline), `npx --offline foo` uses locally-cached binary and fails if there's no cached binary.

I'm going to create a PR for action-stylelint once this PR gets merged