### PR TITLE
Bump eslint-formatter-rdjson v1.0.6

### DIFF
--- a/eslint-formatter-rdjson/package.json
+++ b/eslint-formatter-rdjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-formatter-rdjson",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "ESLint Formatter for the Reviewdog Diagnostic Format (RDFormat)",
   "main": "./index.js",
   "exports": "./index.js",


### PR DESCRIPTION
package.json now includes the "export" field.