### PR TITLE
README: Update actions/setup-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20"
       - run: yarn install


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

`actions/setup-node@v3` runs on Node.js 16.
However, it has been deprecated.
Therefore, I update `actions/setup-node` in `README.md`.