### PR TITLE
renovate: Add stylelint group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,11 @@
   "extends": [
     "config:base"
   ],
-  "rangeStrategy": "replace"
+  "rangeStrategy": "replace",
+  "packageRules": [
+    {
+      "groupName": "stylelint",
+      "matchPackageNames": ["stylelint", "stylelint-config-recommended"]
+    }
+  ]
 }


### PR DESCRIPTION
Accoding to https://github.com/reviewdog/action-eslint/pull/187#issuecomment-1847163085 and https://github.com/reviewdog/action-eslint/pull/188#issuecomment-1847163439, `stylelint` and `stylelint-config-recommended` are interdependent.
Therefore, I fix `renovate.json` to be updated them by renovate in one PR.