### PR TITLE
add Node.js 22 to the build matrix, and remove Node.js 16

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - "16"
           - "18"
           - "20"
+          - "22"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Node.js 22 is current version.
Node.js 16 ends its life on 11 Sep 2023.

https://endoflife.date/nodejs