### PR TITLE
install packages from action folder

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -15,7 +15,7 @@ npx --no-install -c 'eslint --version'
 if [ $? -ne 0 ]; then
   echo '::group:: Running `npm install` to install eslint ...'
   set -e
-  npm install
+  npm install --prefix "${GITHUB_ACTION_PATH}"
   set +e
   echo '::endgroup::'
 fi


### PR DESCRIPTION
makes sure not to install all node packages from the repository that uses the action, but only the node packes required to run it