### PR TITLE
feat: suggest eslint suggestions

### DIFF
--- a/eslint-formatter-rdjson/index.js
+++ b/eslint-formatter-rdjson/index.js
@@ -170,7 +170,13 @@ module.exports = function (results, data) {
       }
 
       if (msg.fix) {
-        diagnostic.suggestions = [buildMinimumSuggestion(msg.fix, source)];
+        diagnostic.suggestions ??= [];
+        diagnostic.suggestions.push(buildMinimumSuggestion(msg.fix, source));
+      }
+
+      if (msg.suggestions) {
+        diagnostic.suggestions ??= [];
+        diagnostic.suggestions.push(...msg.suggestions.map(s => buildMinimumSuggestion(s.fix, source)));
       }
 
       rdjson.diagnostics.push(diagnostic);

--- a/eslint-formatter-rdjson/testdata/result.ok
+++ b/eslint-formatter-rdjson/testdata/result.ok
@@ -551,7 +551,22 @@
         "value": "no-empty",
         "url": "https://eslint.org/docs/latest/rules/no-empty"
       },
-      "original_output": "{\"ruleId\":\"no-empty\",\"severity\":2,\"message\":\"Empty block statement.\",\"line\":11,\"column\":14,\"nodeType\":\"BlockStatement\",\"messageId\":\"unexpected\",\"endLine\":12,\"endColumn\":6,\"suggestions\":[{\"messageId\":\"suggestComment\",\"data\":{\"type\":\"block\"},\"fix\":{\"range\":[194,199],\"text\":\" /* empty */ \"},\"desc\":\"Add comment inside empty block statement.\"}]}"
+      "original_output": "{\"ruleId\":\"no-empty\",\"severity\":2,\"message\":\"Empty block statement.\",\"line\":11,\"column\":14,\"nodeType\":\"BlockStatement\",\"messageId\":\"unexpected\",\"endLine\":12,\"endColumn\":6,\"suggestions\":[{\"messageId\":\"suggestComment\",\"data\":{\"type\":\"block\"},\"fix\":{\"range\":[194,199],\"text\":\" /* empty */ \"},\"desc\":\"Add comment inside empty block statement.\"}]}",
+      "suggestions": [
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "column": 15
+            },
+            "end": {
+              "line": 12,
+              "column": 4
+            }
+          },
+          "text": " /* empty */"
+        }
+      ]
     },
     {
       "message": "Unnecessary semicolon.",


### PR DESCRIPTION
Some rule suggest fixes which are not a direct `fix`.  This make these show up in the rdjson.

I would suggest that in the suggestion definition should be a way to add a description.
As the rule `no-empty` suggests a comment with the description `Add comment inside empty block statement.` this could be very helpful to have context for why a change is suggested. As with other rules this is maybe less clear for the diff.