### PR TITLE
feat: add only_changed option

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -55,3 +55,21 @@ jobs:
           reporter: github-check
           level: warning
           filter_mode: file
+      - name: eslint-only-changed
+        uses: ./
+        with:
+          tool_name: eslint-only-changed
+          reporter: github-check
+          level: warning
+          only_changed: true
+          eslint_flags: "testdata/ --ignore-pattern /test-subproject/"
+      - name: eslint-subproject-only-changed
+        uses: ./
+        with:
+          tool_name: eslint-subproject-only-changed
+          workdir: ./test-subproject
+          reporter: github-check
+          level: warning
+          filter_mode: file
+          only_changed: true
+          eslint_flags: "sub-testdata/"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Optional. The directory from which to look for and run eslint. Default '.'
 
 Optional. The NODE_OPTIONS environment variable to use with eslint. Default is ''.
 
+### `only_changed`
+
+Optional. Run eslint only on changed (and added) files, for speedup [`true`, `false`]. Default: `false`.
+
+Will fetch the tip of the base branch with depth 1 from remote `origin` if it is not available.
+If you use different remote name or customize the checkout otherwise, make the tip of the base branch available before this action.
+
 ## Example usage
 
 You also need to install [eslint](https://github.com/eslint/eslint).

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,14 @@ inputs:
     description: 'NODE_OPTIONS for running eslint'
     required: false
     default: ''
+  only_changed:
+    description: |
+      Run eslint only on changed (and added) files, for speedup [true, false].
+      Default: false.
+      Will fetch the tip of the base branch with depth 1 from remote origin if it is not available.
+      If you use different remote name or customize the checkout otherwise, make the tip of the base branch available before this action.
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -76,6 +84,9 @@ runs:
         INPUT_ESLINT_FLAGS: ${{ inputs.eslint_flags }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}
+        INPUT_ONLY_CHANGED: ${{ inputs.only_changed }}
+        BASE_REF: ${{ github.event.pull_request.base.sha }}
+        HEAD_REF: ${{ github.sha }}
         NODE_OPTIONS: ${{ inputs.node_options }}
 branding:
   icon: 'alert-octagon'

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
 
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
@@ -11,19 +14,57 @@ echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/review
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/fd59714416d6d9a1c0692d872e38e7f8448df4fc/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
-npx --no-install -c 'eslint --version'
-if [ $? -ne 0 ]; then
+if ! npx --no-install -c 'eslint --version'; then
   echo '::group:: Running `npm install` to install eslint ...'
-  set -e
   npm install
-  set +e
   echo '::endgroup::'
 fi
 
 echo "eslint version:$(npx --no-install -c 'eslint --version')"
 
+if [ "${INPUT_ONLY_CHANGED}" = "true" ]; then
+  echo '::group:: Getting changed files list'
+
+  if [ -z "${BASE_REF}" ] || [ -z "${HEAD_REF}" ]; then
+    echo 'BASE_REF or HEAD_REF is not available. Running eslint on all files.'
+  else
+    if ! git cat-file -e "${BASE_REF}"; then
+      git fetch --depth 1 origin "${BASE_REF}"
+    fi
+
+    CHANGED_FILES=()
+    while IFS= read -r file; do
+      CHANGED_FILES+=("${file}")
+    done < <(git diff --relative --diff-filter=d --name-only "${BASE_REF}..${HEAD_REF}")
+
+    if (( ${#CHANGED_FILES[@]} == 0 )); then
+      echo 'No changed files, skipping'
+      exit 0
+    fi
+
+    printf '%s\n' "${CHANGED_FILES[@]}"
+
+    if (( ${#CHANGED_FILES[@]} > 100 )); then
+      echo "More than 100 changed files (${#CHANGED_FILES[@]}), running eslint on all files"
+      unset CHANGED_FILES
+    fi
+  fi
+
+  echo '::endgroup::'
+fi
+
+# shellcheck disable=SC2206
+ESLINT_FLAGS_ARRAY=( ${INPUT_ESLINT_FLAGS:-'.'} )
+
+ESLINT_ARGS=(-f "${ESLINT_FORMATTER}")
+ESLINT_ARGS+=("${ESLINT_FLAGS_ARRAY[@]}")
+if [ -n "${CHANGED_FILES+x}" ]; then
+  ESLINT_ARGS+=("${CHANGED_FILES[@]}")
+fi
+
 echo '::group:: Running eslint with reviewdog 🐶 ...'
-npx --no-install -c "eslint -f="${ESLINT_FORMATTER}" ${INPUT_ESLINT_FLAGS:-'.'}" \
+# shellcheck disable=SC2086
+npx --no-install eslint "${ESLINT_ARGS[@]}" \
   | reviewdog -f=rdjson \
       -name="${INPUT_TOOL_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-review}" \

--- a/script.sh
+++ b/script.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-set -o pipefail
-
 cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
 
 TEMP_PATH="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- add `only_changed` input to the action (default: `false`)
- run eslint only on changed/added files when `only_changed: true`
- fetch base SHA from `origin` with `--depth 1` when missing locally
- skip with exit code 0 when there are no changed files
- document the new option in README

## Why
This aligns `action-eslint` with the `only_changed` behavior provided by `reviewdog/action-rubocop` to speed up checks on pull requests.

## Notes
- existing behavior is unchanged when `only_changed` is `false`
- if changed files are more than 100, it falls back to linting all files
